### PR TITLE
Registry enhancement - Feature to send email to user to update default keycloak password

### DIFF
--- a/java/middleware/registry-middleware/keycloak/src/main/java/dev/sunbirdrc/keycloak/KeycloakAdminUtil.java
+++ b/java/middleware/registry-middleware/keycloak/src/main/java/dev/sunbirdrc/keycloak/KeycloakAdminUtil.java
@@ -34,6 +34,7 @@ public class KeycloakAdminUtil {
     private String authURL;
     private String defaultPassword;
     private boolean setDefaultPassword;
+    private List<String> emailActions;
     private final Keycloak keycloak;
 
     @Autowired
@@ -43,13 +44,15 @@ public class KeycloakAdminUtil {
             @Value("${keycloak-admin.client-id:}") String adminClientId,
             @Value("${keycloak-user.default-password:}") String defaultPassword,
             @Value("${keycloak-user.set-default-password:false}") boolean setDefaultPassword,
-            @Value("${keycloak.auth-server-url:}") String authURL) {
+            @Value("${keycloak.auth-server-url:}") String authURL,
+            @Value("${keycloak-user.emailActions:}") List<String> emailActions) {
         this.realm = realm;
         this.adminClientSecret = adminClientSecret;
         this.adminClientId = adminClientId;
         this.authURL = authURL;
         this.defaultPassword = defaultPassword;
         this.setDefaultPassword = setDefaultPassword;
+        this.emailActions = emailActions;
         this.keycloak = buildKeycloak();
     }
 
@@ -75,6 +78,8 @@ public class KeycloakAdminUtil {
             logger.info("User ID path" + response.getLocation().getPath());
             String userID = response.getLocation().getPath().replaceAll(".*/([^/]+)$", "$1");
             logger.info("User ID : " + userID);
+            if(!emailActions.isEmpty())
+                usersResource.get(userID).executeActionsEmail(emailActions);
             return userID;
         } else if (response.getStatus() == 409) {
             logger.info("UserID: {} exists", userName);

--- a/java/middleware/registry-middleware/keycloak/src/main/java/dev/sunbirdrc/keycloak/KeycloakAdminUtil.java
+++ b/java/middleware/registry-middleware/keycloak/src/main/java/dev/sunbirdrc/keycloak/KeycloakAdminUtil.java
@@ -45,7 +45,7 @@ public class KeycloakAdminUtil {
             @Value("${keycloak-user.default-password:}") String defaultPassword,
             @Value("${keycloak-user.set-default-password:false}") boolean setDefaultPassword,
             @Value("${keycloak.auth-server-url:}") String authURL,
-            @Value("${keycloak-user.emailActions:}") List<String> emailActions) {
+            @Value("${keycloak-user.email-actions:}") List<String> emailActions) {
         this.realm = realm;
         this.adminClientSecret = adminClientSecret;
         this.adminClientId = adminClientId;

--- a/java/registry/src/main/resources/application.yml
+++ b/java/registry/src/main/resources/application.yml
@@ -221,7 +221,7 @@ keycloak-user:
   # email actions which will be trigger by keycloak
   # example email actions: VERIFY_EMAIL, UPDATE_PROFILE, UPDATE_PASSWORD, TERMS_AND_CONDITIONS etc.
   # email details should be configured in keycloak realm settings
-  emailActions: ${keycloack_user_email_actions:UPDATE_PASSWORD}
+  email-actions: ${keycloack_user_email_actions:}
 claims:
   url: ${claims_url:http://localhost:8081}
 authentication:

--- a/java/registry/src/main/resources/application.yml
+++ b/java/registry/src/main/resources/application.yml
@@ -218,6 +218,10 @@ keycloak-admin:
 keycloak-user:
   set-default-password: ${sunbird_keycloak_user_set_password:false}
   default-password: ${sunbird_keycloak_user_password:abcd@123}
+  # email actions which will be trigger by keycloak
+  # example email actions: VERIFY_EMAIL, UPDATE_PROFILE, UPDATE_PASSWORD, TERMS_AND_CONDITIONS etc.
+  # email details should be configured in keycloak realm settings
+  emailActions: ${keycloack_user_email_actions:UPDATE_PASSWORD}
 claims:
   url: ${claims_url:http://localhost:8081}
 authentication:


### PR DESCRIPTION
**Usecase scenario:** 

After creating a user in registry, if `keycloak-user.set-default-password:true` the default password will be set and this will raise security concerns. 

we have implemented a feature to send an email to user with a link to update the password. Using the same password, the user can generate the keycloak token.

**Configuration changes:**

1. Email details should be configured in keycloak realm settings.

![email-settings](https://user-images.githubusercontent.com/80666319/175801913-a6c085fe-43a5-46a2-9b79-d9f11254c54c.jpg)

2. Set the `keycloak-user.email-actions` property to `UPDATE_PASSWORD` in `application.yml` file. To execute the send email action by keycloak, when a user is created.

**Following are the step by step images of the flow:**

Email sent by keycloak to user:

![keycloak-updatemail](https://user-images.githubusercontent.com/80666319/175801680-762ec194-2057-45d7-bfdd-204287d83d6a.jpg)

Clicking the link in the email, user will be redirected to the below page:

<img width="953" alt="k1 (2)" src="https://user-images.githubusercontent.com/80666319/173048481-d7c99145-a613-4e0c-8df7-9fc462c91b13.PNG">

`Click here to proceed` will taken to update password page:

<img width="951" alt="k2 (2)" src="https://user-images.githubusercontent.com/80666319/173048829-de0cd557-152c-46fd-a78a-3f41a7f1c673.PNG">

After setting the password and submitting, user will be taken to confirmation screen:

<img width="959" alt="k3 (2)" src="https://user-images.githubusercontent.com/80666319/173051633-38b76784-e930-4f17-98e4-14f40a483bf9.PNG">

Using the new password, user can generate keycloak token: 

![image](https://user-images.githubusercontent.com/80666319/173052358-29200311-f15e-4d1d-9a8a-62ab1f516623.png)

**Discussion link:** https://github.com/Sunbird-RC/community/discussions/118