### PR TITLE
Registry enhancement - Feature to add keycloak roles to the users

### DIFF
--- a/java/middleware-commons/src/main/java/dev/sunbirdrc/registry/middleware/util/Constants.java
+++ b/java/middleware-commons/src/main/java/dev/sunbirdrc/registry/middleware/util/Constants.java
@@ -110,6 +110,7 @@ public class Constants {
 	public static final String USER_ID = "userId";
 	public static final String EMAIL = "email";
 	public static final String MOBILE = "mobile";
+	public static final String ROLES = "roles";
 	public static final String SVG_MEDIA_TYPE = "image/svg+xml";
 
     public enum GraphDatabaseProvider {

--- a/java/middleware-commons/src/main/java/dev/sunbirdrc/registry/middleware/util/JSONUtil.java
+++ b/java/middleware-commons/src/main/java/dev/sunbirdrc/registry/middleware/util/JSONUtil.java
@@ -69,6 +69,10 @@ public class JSONUtil {
 		return mapObject;
 	}
 
+	public static List<String> convertJsonNodeToList(Object obj){
+		return new ObjectMapper().convertValue(obj, List.class);
+	}
+
 	public static String getStringWithReplacedText(String payload, String value, String replacement) {
 		Pattern pattern = Pattern.compile(value);
 		Matcher matcher = pattern.matcher(payload);

--- a/java/middleware/registry-middleware/keycloak/pom.xml
+++ b/java/middleware/registry-middleware/keycloak/pom.xml
@@ -45,6 +45,11 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
+            <groupId>dev.sunbirdrc</groupId>
+            <artifactId>middleware-commons</artifactId>
+            <version>2.0.3</version>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>

--- a/java/middleware/registry-middleware/keycloak/src/main/java/dev/sunbirdrc/keycloak/KeycloakAdminUtil.java
+++ b/java/middleware/registry-middleware/keycloak/src/main/java/dev/sunbirdrc/keycloak/KeycloakAdminUtil.java
@@ -1,11 +1,14 @@
 package dev.sunbirdrc.keycloak;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import dev.sunbirdrc.registry.middleware.util.JSONUtil;
 import org.keycloak.OAuth2Constants;
 import org.keycloak.admin.client.Keycloak;
 import org.keycloak.admin.client.KeycloakBuilder;
 import org.keycloak.admin.client.resource.*;
 import org.keycloak.representations.idm.CredentialRepresentation;
 import org.keycloak.representations.idm.GroupRepresentation;
+import org.keycloak.representations.idm.RoleRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -63,8 +66,9 @@ public class KeycloakAdminUtil {
                 .build();
     }
 
-    public String createUser(String entityName, String userName, String email, String mobile) throws OwnerCreationException {
+    public String createUser(String entityName, String userName, String email, String mobile, JsonNode realmRoles) throws OwnerCreationException {
         logger.info("Creating user with mobile_number : " + userName);
+        List<String> roles = JSONUtil.convertJsonNodeToList(realmRoles);
         UserRepresentation newUser = createUserRepresentation(entityName, userName, email, mobile);
         GroupRepresentation entityGroup = createGroupRepresentation(entityName);
         keycloak.realm(realm).groups().add(entityGroup);
@@ -75,14 +79,30 @@ public class KeycloakAdminUtil {
             logger.info("User ID path" + response.getLocation().getPath());
             String userID = response.getLocation().getPath().replaceAll(".*/([^/]+)$", "$1");
             logger.info("User ID : " + userID);
+            addRolesToUser(roles, userID);
             return userID;
         } else if (response.getStatus() == 409) {
             logger.info("UserID: {} exists", userName);
-            return updateExistingUserAttributes(entityName, userName, email, mobile);
+            return updateExistingUserAttributes(entityName, userName, email, mobile, roles);
         } else if (response.getStatus() == 500) {
             throw new OwnerCreationException("Keycloak user creation error");
         }else {
             throw new OwnerCreationException("Username already invited / registered");
+        }
+    }
+
+    private void addRolesToUser(List<String> roles, String userID){
+        /** Add the 'view-realm' role to client to access the keycloak roles
+         * Go to Keycloak -> open client(which is configured as client_id in application.yml) ->
+         * Service Account Roles -> Client Roles, select 'realm-management' -> Assign 'view-relam' role
+         */
+        if(!roles.isEmpty()) {
+            List<RoleRepresentation> roleToAdd = new ArrayList<>();
+            for (String role : roles) {
+                roleToAdd.add(keycloak.realm(realm).roles().get(role).toRepresentation());
+            }
+            UserResource userResource = keycloak.realm(realm).users().get(userID);
+            userResource.roles().realmLevel().add(roleToAdd);
         }
     }
 
@@ -92,7 +112,7 @@ public class KeycloakAdminUtil {
         return groupRepresentation;
     }
 
-    private String updateExistingUserAttributes(String entityName, String userName, String email, String mobile) throws OwnerCreationException {
+    private String updateExistingUserAttributes(String entityName, String userName, String email, String mobile, List<String> roles) throws OwnerCreationException {
         Optional<UserResource> userRepresentationOptional = getUserByUsername(userName);
         if (userRepresentationOptional.isPresent()) {
             UserResource userResource = userRepresentationOptional.get();
@@ -100,6 +120,7 @@ public class KeycloakAdminUtil {
             checkIfUserRegisteredForEntity(entityName, userRepresentation);
             updateUserAttributes(entityName, email, mobile, userRepresentation);
             userResource.update(userRepresentation);
+            addRolesToUser(roles, userName);
             return userRepresentation.getId();
         } else {
             logger.error("Failed fetching user by username: {}", userName);

--- a/java/middleware/registry-middleware/workflow/src/main/resources/workflow/statetransitions.drl
+++ b/java/middleware/registry-middleware/workflow/src/main/resources/workflow/statetransitions.drl
@@ -41,7 +41,7 @@ rule "Create entity owner for newly added owner fields"
         stateDefinition:StateContext(isOwnershipProperty() && isOwnerNewlyAdded() && isLoginEnabled());
     then
         String owner = keycloakAdminUtil.createUser(stateDefinition.getEntityName(), stateDefinition.getUpdated().get("userId").textValue(),
-        stateDefinition.getUpdated().get("email").textValue(), stateDefinition.getUpdated().get("mobile").textValue());
+        stateDefinition.getUpdated().get("email").textValue(), stateDefinition.getUpdated().get("mobile").textValue(), stateDefinition.getUpdated().get("roles"));
         stateDefinition.addOwner(owner);
 end
 

--- a/java/registry/src/main/java/dev/sunbirdrc/registry/helper/EntityStateHelper.java
+++ b/java/registry/src/main/java/dev/sunbirdrc/registry/helper/EntityStateHelper.java
@@ -119,6 +119,7 @@ public class EntityStateHelper {
         objectNode.put(MOBILE, entityNode.at(String.format("/%s%s", entityName, mobilePath)).asText(""));
         objectNode.put(EMAIL, entityNode.at(String.format("/%s%s", entityName, emailPath)).asText(""));
         objectNode.put(USER_ID, entityNode.at(String.format("/%s%s", entityName, userIdPath)).asText(""));
+        objectNode.set(ROLES, entityNode.at(String.format("/%s", entityName)).has(ROLES) ? entityNode.at(String.format("/%s%s", entityName, "/roles")) : new ObjectMapper().createArrayNode());
         return objectNode;
     }
 

--- a/java/registry/src/test/java/dev/sunbirdrc/registry/helper/EntityStateHelperTest.java
+++ b/java/registry/src/test/java/dev/sunbirdrc/registry/helper/EntityStateHelperTest.java
@@ -39,6 +39,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
@@ -111,21 +112,21 @@ public class EntityStateHelperTest {
 
     @Test
     public void shouldCreateNewOwnersForNewlyAddedOwnerFields() throws IOException, DuplicateRecordException, EntityCreationException, OwnerCreationException {
-        when(keycloakAdminUtil.createUser(anyString(), anyString(), anyString(), anyString())).thenReturn("456");
+        when(keycloakAdminUtil.createUser(anyString(), anyString(), anyString(), anyString(), any())).thenReturn("456");
         JsonNode test = m.readTree(new File(getBaseDir() + "shouldAddNewOwner.json"));
         runTest(test.get("existing"), test.get("updated"), test.get("expected"), Collections.emptyList());
     }
 
     @Test
     public void shouldNotCreateNewOwners() throws IOException, DuplicateRecordException, EntityCreationException, OwnerCreationException {
-        when(keycloakAdminUtil.createUser(anyString(), anyString(), anyString(), anyString())).thenReturn("456");
+        when(keycloakAdminUtil.createUser(anyString(), anyString(), anyString(), anyString(), any())).thenReturn("456");
         JsonNode test = m.readTree(new File(getBaseDir() + "shouldNotAddNewOwner.json"));
         runTest(test.get("existing"), test.get("updated"), test.get("expected"), Collections.emptyList());
     }
 
     @Test
     public void shouldNotModifyExistingOwners() throws IOException, DuplicateRecordException, EntityCreationException, OwnerCreationException {
-        when(keycloakAdminUtil.createUser(anyString(), anyString(), anyString(), anyString())).thenReturn("456");
+        when(keycloakAdminUtil.createUser(anyString(), anyString(), anyString(), anyString(),any())).thenReturn("456");
         JsonNode test = m.readTree(new File(getBaseDir() + "shouldNotModifyExistingOwner.json"));
         runTest(test.get("existing"), test.get("updated"), test.get("expected"), Collections.emptyList());
     }

--- a/java/registry/src/test/java/dev/sunbirdrc/registry/helper/RegistryHelperTest.java
+++ b/java/registry/src/test/java/dev/sunbirdrc/registry/helper/RegistryHelperTest.java
@@ -314,7 +314,7 @@ public class RegistryHelperTest {
         JsonNode inviteJson = new ObjectMapper().readTree("{\"Institute\":{\"email\":\"gecasu.ihises@tovinit.com\",\"instituteName\":\"gecasu\"}}");
         mockDefinitionManager();
         String testUserId = "be6d30e9-7c62-4a05-b4c8-ee28364da8e4";
-        when(keycloakAdminUtil.createUser(any(), any(), any(), any())).thenReturn(testUserId);
+        when(keycloakAdminUtil.createUser(any(), any(), any(), any(), any())).thenReturn(testUserId);
         when(registryService.addEntity(any(), any(), any(), anyBoolean())).thenReturn(UUID.randomUUID().toString());
         when(shardManager.getShard(any())).thenReturn(new Shard());
         ReflectionTestUtils.setField(registryHelper, "workflowEnabled", true);
@@ -328,7 +328,7 @@ public class RegistryHelperTest {
         JsonNode inviteJson = new ObjectMapper().readTree("{\"Institute\":{\"email\":\"gecasu.ihises@tovinit.com\",\"instituteName\":\"gecasu\"}}");
         mockDefinitionManager();
         String testUserId = "be6d30e9-7c62-4a05-b4c8-ee28364da8e4";
-        when(keycloakAdminUtil.createUser(any(), any(), any(), any())).thenReturn(testUserId);
+        when(keycloakAdminUtil.createUser(any(), any(), any(), any(), any())).thenReturn(testUserId);
         when(registryService.addEntity(any(), any(), any(), anyBoolean())).thenReturn(UUID.randomUUID().toString());
         when(shardManager.getShard(any())).thenReturn(new Shard());
         registryHelper.inviteEntity(inviteJson, "");
@@ -358,7 +358,7 @@ public class RegistryHelperTest {
                 "  \"adminMobile\": \"1234\"\n" +
                 "}}");
         String testUserId = "be6d30e9-7c62-4a05-b4c8-ee28364da8e4";
-        when(keycloakAdminUtil.createUser(any(), any(), any(), any())).thenReturn(testUserId);
+        when(keycloakAdminUtil.createUser(any(), any(), any(), any(), any())).thenReturn(testUserId);
         when(registryService.addEntity(any(), any(), any(), anyBoolean())).thenReturn(UUID.randomUUID().toString());
         when(shardManager.getShard(any())).thenReturn(new Shard());
         mockDefinitionManager();


### PR DESCRIPTION
**Usecase scenario:** 
Creating a user in the registry will create a user in keycloak. currently, we don't have any feature in registry to add keycloak roles to users. 

This will help to give different privileges to users. For example, we can give access to different users to different APIs based on the roles, which can be extracted from JWT token(as it contains role information).

**Discussion link:** https://github.com/Sunbird-RC/community/discussions/178