### PR TITLE
Registry enhancement - Feature to enable/disable adding shard label to record identifiers

### DIFF
--- a/java/registry/src/main/java/dev/sunbirdrc/registry/helper/RegistryHelper.java
+++ b/java/registry/src/main/java/dev/sunbirdrc/registry/helper/RegistryHelper.java
@@ -130,6 +130,9 @@ public class RegistryHelper {
     @Value("${workflow.enabled:true}")
     private boolean workflowEnabled;
 
+    @Value("${database.enableSharding}")
+    private boolean enableSharding;
+
     @Autowired
     private EntityTypeHandler entityTypeHandler;
 
@@ -223,6 +226,8 @@ public class RegistryHelper {
             Shard shard = shardManager.getShard(inputJson.get(entityType).get(shardManager.getShardProperty()));
             watch.start("RegistryController.addToExistingEntity");
             String resultId = registryService.addEntity(shard, userId, inputJson, skipSignature);
+            if (!enableSharding)
+                shard.setShardLabel("");
             recordId = new RecordIdentifier(shard.getShardLabel(), resultId);
             watch.stop("RegistryController.addToExistingEntity");
             logger.info("AddEntity,{}", recordId.toString());

--- a/java/registry/src/main/resources/application.yml
+++ b/java/registry/src/main/resources/application.yml
@@ -113,6 +113,10 @@ database:
   # If this property not provided, advisor is set to DefaultShardAdvisor
   shardAdvisorClassName: dev.sunbirdrc.registry.sink.shard.DefaultShardAdvisor
 
+  # To enable/disable sharding, If false, shardLabel(example: '1-')
+  # will not be added as prefix to record identifier
+  enableSharding: ${database_enableSharding:false}
+
   connectionInfo:
     - # shardId, shardlabel must be a unique identifier to each connection.
       shardId: shard1

--- a/java/registry/src/main/resources/application.yml
+++ b/java/registry/src/main/resources/application.yml
@@ -115,7 +115,7 @@ database:
 
   # To enable/disable sharding, If false, shardLabel(example: '1-')
   # will not be added as prefix to record identifier
-  enableSharding: ${database_enableSharding:false}
+  enableSharding: ${database_enableSharding:true}
 
   connectionInfo:
     - # shardId, shardlabel must be a unique identifier to each connection.

--- a/java/registry/src/test/java/dev/sunbirdrc/registry/helper/RegistryHelperTest.java
+++ b/java/registry/src/test/java/dev/sunbirdrc/registry/helper/RegistryHelperTest.java
@@ -42,7 +42,7 @@ import java.io.IOException;
 import java.nio.charset.Charset;
 import java.util.*;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
@@ -321,6 +321,40 @@ public class RegistryHelperTest {
         registryHelper.inviteEntity(inviteJson, "");
         Mockito.verify(registryService).addEntity(shardCapture.capture(), userIdCapture.capture(), inputJsonCapture.capture(), anyBoolean());
         assertEquals("{\"Institute\":{\"email\":\"gecasu.ihises@tovinit.com\",\"instituteName\":\"gecasu\",\"osOwner\":[\"" + testUserId + "\"]}}", inputJsonCapture.getValue().toString());
+    }
+
+    @Test
+    public void enableShardingIsFalse() throws Exception {
+        JsonNode inviteJson = new ObjectMapper().readTree("{\"Institute\":{\"email\":\"gecasu.ihises@tovinit.com\",\"instituteName\":\"gecasu\"}}");
+        mockDefinitionManager();
+        String testUserId = "be6d30e9-7c62-4a05-b4c8-ee28364da8e4";
+        when(keycloakAdminUtil.createUser(any(), any(), any(), any())).thenReturn(testUserId);
+        when(registryService.addEntity(any(), any(), any(), anyBoolean())).thenReturn(UUID.randomUUID().toString());
+        Shard shard = new Shard();
+        shard.setShardLabel("1");
+        when(shardManager.getShard(any())).thenReturn(shard);
+        ReflectionTestUtils.setField(registryHelper, "workflowEnabled", true);
+        ReflectionTestUtils.setField(registryHelper, "enableSharding", false);
+        String id = registryHelper.inviteEntity(inviteJson, "");
+        Mockito.verify(registryService).addEntity(shardCapture.capture(), userIdCapture.capture(), inputJsonCapture.capture(), anyBoolean());
+        assertFalse(id.contains("1-"));
+    }
+
+    @Test
+    public void enableShardingIsTrue() throws Exception {
+        JsonNode inviteJson = new ObjectMapper().readTree("{\"Institute\":{\"email\":\"gecasu.ihises@tovinit.com\",\"instituteName\":\"gecasu\"}}");
+        mockDefinitionManager();
+        String testUserId = "be6d30e9-7c62-4a05-b4c8-ee28364da8e4";
+        when(keycloakAdminUtil.createUser(any(), any(), any(), any())).thenReturn(testUserId);
+        when(registryService.addEntity(any(), any(), any(), anyBoolean())).thenReturn(UUID.randomUUID().toString());
+        Shard shard = new Shard();
+        shard.setShardLabel("1");
+        when(shardManager.getShard(any())).thenReturn(shard);
+        ReflectionTestUtils.setField(registryHelper, "workflowEnabled", true);
+        ReflectionTestUtils.setField(registryHelper, "enableSharding", true);
+        String id = registryHelper.inviteEntity(inviteJson, "");
+        Mockito.verify(registryService).addEntity(shardCapture.capture(), userIdCapture.capture(), inputJsonCapture.capture(), anyBoolean());
+        assertTrue(id.contains("1-"));
     }
 
     @Test


### PR DESCRIPTION
**Usecase scenario:**
The value of the `osId` property is having two formats of the data. Below are the details.

Invite API response returning osId as like `<shardId>-<uuid>`. Ex: `1-1206f8fc-0dd4-43fa-a8fb-f74a3f265cc8`
Search API response returning osId as like `<uuid>` only. Ex: `1206f8fc-0dd4-43fa-a8fb-f74a3f265cc8`

Having multiple `shardId` values for the registry instance may not be consistent and create confusion. We have added a configurable property to disable adding shard label to record identifier.

**Discussion link:** https://github.com/Sunbird-RC/community/discussions/130