### PR TITLE
Registry enhancement - Feature to use custom id as record identifier instead of UUID

### DIFF
--- a/java/registry/src/main/java/dev/sunbirdrc/registry/dao/VertexWriter.java
+++ b/java/registry/src/main/java/dev/sunbirdrc/registry/dao/VertexWriter.java
@@ -210,6 +210,10 @@ public class VertexWriter {
 
     private Vertex processNode(String label, JsonNode jsonObject) {
         Vertex vertex = createVertex(label);
+        if(!databaseProvider.getCustomIdentifierPropertyName().isEmpty()) {
+            if (jsonObject.has(databaseProvider.getCustomIdentifierPropertyName()))
+                vertex.property(uuidPropertyName, jsonObject.get(databaseProvider.getCustomIdentifierPropertyName()).textValue());
+        }
         identifyParentOSid(vertex);
 
         jsonObject.fields().forEachRemaining(entry -> {

--- a/java/registry/src/main/java/dev/sunbirdrc/registry/helper/RegistryHelper.java
+++ b/java/registry/src/main/java/dev/sunbirdrc/registry/helper/RegistryHelper.java
@@ -130,6 +130,9 @@ public class RegistryHelper {
     @Value("${workflow.enabled:true}")
     private boolean workflowEnabled;
 
+    @Value("${database.customIdentifierPropertyName}")
+    private String customIdentifierPropertyName;
+
     @Autowired
     private EntityTypeHandler entityTypeHandler;
 
@@ -221,6 +224,8 @@ public class RegistryHelper {
         try {
             logger.info("Add api: entity type: {} and shard propery: {}", entityType, shardManager.getShardProperty());
             Shard shard = shardManager.getShard(inputJson.get(entityType).get(shardManager.getShardProperty()));
+            if(!customIdentifierPropertyName.isEmpty())
+                shard.getDatabaseProvider().setCustomIdentifierPropertyName(customIdentifierPropertyName);
             watch.start("RegistryController.addToExistingEntity");
             String resultId = registryService.addEntity(shard, userId, inputJson, skipSignature);
             recordId = new RecordIdentifier(shard.getShardLabel(), resultId);

--- a/java/registry/src/main/java/dev/sunbirdrc/registry/sink/DatabaseProvider.java
+++ b/java/registry/src/main/java/dev/sunbirdrc/registry/sink/DatabaseProvider.java
@@ -17,6 +17,7 @@ import java.util.UUID;
 public abstract class DatabaseProvider {
     private Constants.GraphDatabaseProvider provider;
     private String uuidPropertyName;
+    private String customIdentifierPropertyName;
     private Optional<Boolean> supportsTransaction = Optional.empty();
 
     private static Logger logger = LoggerFactory.getLogger(DatabaseProvider.class);
@@ -166,5 +167,13 @@ public abstract class DatabaseProvider {
 
     protected void setProvider(Constants.GraphDatabaseProvider provider) {
         this.provider = provider;
+    }
+
+    public void setCustomIdentifierPropertyName(String customIdentifierPropertyName) {
+        this.customIdentifierPropertyName = customIdentifierPropertyName;
+    }
+
+    public String getCustomIdentifierPropertyName() {
+        return customIdentifierPropertyName;
     }
 }

--- a/java/registry/src/main/resources/application.yml
+++ b/java/registry/src/main/resources/application.yml
@@ -113,6 +113,11 @@ database:
   # If this property not provided, advisor is set to DefaultShardAdvisor
   shardAdvisorClassName: dev.sunbirdrc.registry.sink.shard.DefaultShardAdvisor
 
+  # Instead of uuid, we can enable to use custom property value as a unique record identifier
+  # value will be set to below defined property, passed in request body and the same value will
+  # be used as record identifier
+  customIdentifierPropertyName: ${database_customIdentifierPropertyName:recordId}
+
   connectionInfo:
     - # shardId, shardlabel must be a unique identifier to each connection.
       shardId: shard1


### PR DESCRIPTION
**Usecase scenario:**

Creating a user in the registry will give UUID as a record identifier. UUID is very unique, but not human-readable. In some cases, we might need a human-readable id as a record identifier. 

Example: In the education registry, the user id can be a combination of name and role and it will be human-readable (`"userId": "teacher-ravi-kumar"`).

We have implemented the feature to use a custom id as a record identifier. we have to set the custom id property to `database.customIdentifierPropertyName` in `application.yml` and the same property along with custom id value should be passed in request body. Registry will use the custom id as `osid`. 

User need not give his own id, we can write some wrapper API on top of registry invite API and generate the userid in wrapper and add it to request body and route it to invite API.

```
{  
   "userId": "teacher-ravi-kumar",
   "name": "Ravi kumar",
   "roles": ["teacher"],
   "email: "ravi.kumar@gmail.com",
   "phone": "9666505050"
}
```

**Discussion link:** 